### PR TITLE
Fix build for stimulus 3.0

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "lib": ["dom", "es2015"],
     "declaration": true, 


### PR DESCRIPTION
We previously transpiled typescript to ES5, this caused some problems when using stimulus 3. We now build to ES6